### PR TITLE
Remove mv capture

### DIFF
--- a/c++/src/capnp/capability.c++
+++ b/c++/src/capnp/capability.c++
@@ -239,8 +239,7 @@ public:
         .detach([](kj::Exception&&) {});  // ignore exceptions
 
     // Now the other branch returns the response from the context.
-    auto promise = forked.addBranch().then(kj::mvCapture(context,
-        [](kj::Own<LocalCallContext>&& context) {
+    auto promise = forked.addBranch().then([context=kj::mv(context)]() mutable {
       // force response allocation
       auto reader = context->getResults(MessageSize { 0, 0 }).asReader();
 
@@ -258,7 +257,7 @@ public:
       } else {
         return kj::mv(KJ_ASSERT_NONNULL(context->response));
       }
-    }));
+    });
 
     // We return the other branch.
     return RemotePromise<AnyPointer>(
@@ -422,11 +421,11 @@ public:
 
     // Create a promise for the call initiation.
     kj::ForkedPromise<kj::Own<CallResultHolder>> callResultPromise =
-        promiseForCallForwarding.addBranch().then(kj::mvCapture(context,
-        [=](kj::Own<CallContextHook>&& context, kj::Own<ClientHook>&& client){
+        promiseForCallForwarding.addBranch().then(
+        [=,context=kj::mv(context)](kj::Own<ClientHook>&& client) mutable {
           return kj::refcounted<CallResultHolder>(
               client->call(interfaceId, methodId, kj::mv(context)));
-        })).fork();
+        }).fork();
 
     // Create a promise that extracts the pipeline from the call initiation, and construct our
     // QueuedPipeline to chain to it.
@@ -606,11 +605,12 @@ public:
     // We have to fork this promise for the pipeline to receive a copy of the answer.
     auto forked = promise.fork();
 
-    auto pipelinePromise = forked.addBranch().then(kj::mvCapture(context->addRef(),
-        [=](kj::Own<CallContextHook>&& context) -> kj::Own<PipelineHook> {
+    auto contextRef = context->addRef();
+    auto pipelinePromise = forked.addBranch()
+        .then([=,context=kj::mv(contextRef)]() mutable -> kj::Own<PipelineHook> {
           context->releaseParams();
           return kj::refcounted<LocalPipeline>(kj::mv(context));
-        }));
+        });
 
     auto tailPipelinePromise = context->onTailCall().then([](AnyPointer::Pipeline&& pipeline) {
       return kj::mv(pipeline.hook);

--- a/c++/src/capnp/compat/byte-stream-test.c++
+++ b/c++/src/capnp/compat/byte-stream-test.c++
@@ -33,7 +33,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
   auto buffer = kj::heapArray<char>(expected.size());
 
   auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
-  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+  return promise.then([&in,expected,buffer=kj::mv(buffer)](size_t amount) {
     if (amount == 0) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
@@ -44,7 +44,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
     }
 
     return expectRead(in, expected.slice(amount));
-  }));
+  });
 }
 
 kj::String makeString(size_t size) {

--- a/c++/src/capnp/compat/http-over-capnp-test.c++
+++ b/c++/src/capnp/compat/http-over-capnp-test.c++
@@ -42,7 +42,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
   auto buffer = kj::heapArray<char>(expected.size());
 
   auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
-  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+  return promise.then([&in,expected,buffer=kj::mv(buffer)](size_t amount) {
     if (amount == 0) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
@@ -53,7 +53,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
     }
 
     return expectRead(in, expected.slice(amount));
-  }));
+  });
 }
 
 enum Direction {

--- a/c++/src/capnp/ez-rpc.c++
+++ b/c++/src/capnp/ez-rpc.c++
@@ -177,10 +177,11 @@ Capability::Client EzRpcClient::importCap(kj::StringPtr name) {
   KJ_IF_MAYBE(client, impl->clientContext) {
     return client->get()->restore(name);
   } else {
-    return impl->setupPromise.addBranch().then(kj::mvCapture(kj::heapString(name),
-        [this](kj::String&& name) {
+    auto nameCopy = kj::heapString(name);
+    return impl->setupPromise.addBranch().then(
+        [this,name=kj::mv(nameCopy)]() {
       return KJ_ASSERT_NONNULL(impl->clientContext)->restore(name);
-    }));
+    });
   }
 }
 
@@ -260,13 +261,11 @@ struct EzRpcServer::Impl final: public SturdyRefRestorer<AnyPointer>,
     portPromise = paf.promise.fork();
 
     tasks.add(context->getIoProvider().getNetwork().parseAddress(bindAddress, defaultPort)
-        .then(kj::mvCapture(paf.fulfiller,
-          [this, readerOpts](kj::Own<kj::PromiseFulfiller<uint>>&& portFulfiller,
-                             kj::Own<kj::NetworkAddress>&& addr) {
+        .then([this, portFulfiller=kj::mv(paf.fulfiller), readerOpts](kj::Own<kj::NetworkAddress>&& addr) mutable {
       auto listener = addr->listen();
       portFulfiller->fulfill(listener->getPort());
       acceptLoop(kj::mv(listener), readerOpts);
-    })));
+    }));
   }
 
   Impl(Capability::Client mainInterface, struct sockaddr* bindAddress, uint addrSize,
@@ -290,9 +289,7 @@ struct EzRpcServer::Impl final: public SturdyRefRestorer<AnyPointer>,
 
   void acceptLoop(kj::Own<kj::ConnectionReceiver>&& listener, ReaderOptions readerOpts) {
     auto ptr = listener.get();
-    tasks.add(ptr->accept().then(kj::mvCapture(kj::mv(listener),
-        [this, readerOpts](kj::Own<kj::ConnectionReceiver>&& listener,
-                           kj::Own<kj::AsyncIoStream>&& connection) {
+    tasks.add(ptr->accept().then([this, listener=kj::mv(listener), readerOpts](kj::Own<kj::AsyncIoStream>&& connection) mutable {
       acceptLoop(kj::mv(listener), readerOpts);
 
       auto server = kj::heap<ServerContext>(kj::mv(connection), *this, readerOpts);
@@ -300,7 +297,7 @@ struct EzRpcServer::Impl final: public SturdyRefRestorer<AnyPointer>,
       // Arrange to destroy the server context when all references are gone, or when the
       // EzRpcServer is destroyed (which will destroy the TaskSet).
       tasks.add(server->network.onDisconnect().attach(kj::mv(server)));
-    })));
+    }));
   }
 
   Capability::Client restore(AnyPointer::Reader objectId) override {

--- a/c++/src/capnp/rpc-test.c++
+++ b/c++/src/capnp/rpc-test.c++
@@ -288,8 +288,8 @@ public:
         auto incomingMessage = kj::heap<IncomingRpcMessageImpl>(messageToFlatArray(message));
 
         auto connectionPtr = &connection;
-        connection.tasks->add(kj::evalLater(kj::mvCapture(incomingMessage,
-            [connectionPtr](kj::Own<IncomingRpcMessageImpl>&& message) {
+        connection.tasks->add(kj::evalLater(
+            [connectionPtr,message=kj::mv(incomingMessage)]() mutable {
           KJ_IF_MAYBE(p, connectionPtr->partner) {
             if (p->fulfillers.empty()) {
               p->messages.push(kj::mv(message));
@@ -300,7 +300,7 @@ public:
               p->fulfillers.pop();
             }
           }
-        })));
+        }));
       }
 
       size_t sizeInWords() override {

--- a/c++/src/capnp/serialize-async.c++
+++ b/c++/src/capnp/serialize-async.c++
@@ -295,7 +295,7 @@ kj::Promise<void> writeMessageImpl(kj::ArrayPtr<const kj::ArrayPtr<const word>> 
   auto promise = writeFunc(arrays.pieces);
 
   // Make sure the arrays aren't freed until the write completes.
-  return promise.then(kj::mvCapture(arrays, [](WriteArrays&&) {}));
+  return promise.then([arrays=kj::mv(arrays)]() {});
 }
 
 template <typename WriteFunc>

--- a/c++/src/kj/async-io-test.c++
+++ b/c++/src/kj/async-io-test.c++
@@ -1235,7 +1235,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
   auto buffer = kj::heapArray<char>(expected.size());
 
   auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
-  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+  return promise.then([&in,expected,buffer=kj::mv(buffer)](size_t amount) {
     if (amount == 0) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
@@ -1246,7 +1246,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
     }
 
     return expectRead(in, expected.slice(amount));
-  }));
+  });
 }
 
 class MockAsyncInputStream final: public AsyncInputStream {

--- a/c++/src/kj/async-io.c++
+++ b/c++/src/kj/async-io.c++
@@ -2749,9 +2749,9 @@ Promise<Own<AsyncIoStream>> CapabilityStreamNetworkAddress::connect() {
   }
   auto result = kj::mv(pipe.ends[0]);
   return inner.sendStream(kj::mv(pipe.ends[1]))
-      .then(kj::mvCapture(result, [](Own<AsyncIoStream>&& result) {
-    return kj::mv(result);
-  }));
+      .then([result=kj::mv(result)]() mutable {
+    return Own<AsyncIoStream>(kj::mv(result));
+  });
 }
 Promise<AuthenticatedStream> CapabilityStreamNetworkAddress::connectAuthenticated() {
   return connect().then([](Own<AsyncIoStream>&& stream) {

--- a/c++/src/kj/async-test.c++
+++ b/c++/src/kj/async-test.c++
@@ -227,9 +227,9 @@ TEST(Async, DeepChain) {
 
   // Create a ridiculous chain of promises.
   for (uint i = 0; i < 1000; i++) {
-    promise = evalLater(mvCapture(promise, [](Promise<void> promise) {
+    promise = evalLater([promise=kj::mv(promise)]() mutable {
       return kj::mv(promise);
-    }));
+    });
   }
 
   loop.run();
@@ -264,9 +264,9 @@ TEST(Async, DeepChain2) {
 
   // Create a ridiculous chain of promises.
   for (uint i = 0; i < 1000; i++) {
-    promise = evalLater(mvCapture(promise, [](Promise<void> promise) {
+    promise = evalLater([promise=kj::mv(promise)]() mutable {
       return kj::mv(promise);
-    }));
+    });
   }
 
   promise.wait(waitScope);
@@ -303,9 +303,9 @@ TEST(Async, DeepChain3) {
 
 Promise<void> makeChain2(uint i, Promise<void> promise) {
   if (i > 0) {
-    return evalLater(mvCapture(promise, [i](Promise<void>&& promise) -> Promise<void> {
+    return evalLater([i, promise=kj::mv(promise)]() mutable -> Promise<void> {
       return makeChain2(i - 1, kj::mv(promise));
-    }));
+    });
   } else {
     return kj::mv(promise);
   }

--- a/c++/src/kj/async.h
+++ b/c++/src/kj/async.h
@@ -570,21 +570,6 @@ private:
   MovedParam param;
 };
 
-template <typename Func, typename MovedParam>
-inline CaptureByMove<Func, Decay<MovedParam>> mvCapture(MovedParam&& param, Func&& func) {
-  // Hack to create a "lambda" which captures a variable by moving it rather than copying or
-  // referencing.  C++14 generalized captures should make this obsolete, but for now in C++11 this
-  // is commonly needed for Promise continuations that own their state.  Example usage:
-  //
-  //    Own<Foo> ptr = makeFoo();
-  //    Promise<int> promise = callRpc();
-  //    promise.then(mvCapture(ptr, [](Own<Foo>&& ptr, int result) {
-  //      return ptr->finish(result);
-  //    }));
-
-  return CaptureByMove<Func, Decay<MovedParam>>(kj::fwd<Func>(func), kj::mv(param));
-}
-
 // =======================================================================================
 // Advanced promise construction
 

--- a/c++/src/kj/compat/http-test.c++
+++ b/c++/src/kj/compat/http-test.c++
@@ -535,7 +535,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
   auto buffer = kj::heapArray<char>(expected.size());
 
   auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
-  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<char> buffer, size_t amount) {
+  return promise.then([&in,expected,buffer=kj::mv(buffer)](size_t amount) {
     if (amount == 0) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
@@ -546,7 +546,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::StringPtr expected) {
     }
 
     return expectRead(in, expected.slice(amount));
-  }));
+  });
 }
 
 kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::ArrayPtr<const byte> expected) {
@@ -555,7 +555,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::ArrayPtr<const byte> 
   auto buffer = kj::heapArray<byte>(expected.size());
 
   auto promise = in.tryRead(buffer.begin(), 1, buffer.size());
-  return promise.then(kj::mvCapture(buffer, [&in,expected](kj::Array<byte> buffer, size_t amount) {
+  return promise.then([&in,expected,buffer=kj::mv(buffer)](size_t amount) {
     if (amount == 0) {
       KJ_FAIL_ASSERT("expected data never sent", expected);
     }
@@ -566,7 +566,7 @@ kj::Promise<void> expectRead(kj::AsyncInputStream& in, kj::ArrayPtr<const byte> 
     }
 
     return expectRead(in, expected.slice(amount, expected.size()));
-  }));
+  });
 }
 
 kj::Promise<void> expectEnd(kj::AsyncInputStream& in) {

--- a/c++/src/kj/compat/tls-test.c++
+++ b/c++/src/kj/compat/tls-test.c++
@@ -589,10 +589,10 @@ kj::Promise<void> readN(kj::AsyncIoStream& stream, kj::StringPtr text, size_t co
   --count;
   auto buf = kj::heapString(text.size());
   auto promise = stream.read(buf.begin(), buf.size());
-  return promise.then(kj::mvCapture(buf, [&stream, text, count](kj::String buf) {
+  return promise.then([&stream, text, buf=kj::mv(buf), count]() {
     KJ_ASSERT(buf == text, buf, text, count);
     return readN(stream, text, count);
-  }));
+  });
 }
 
 KJ_TEST("TLS full duplex") {


### PR DESCRIPTION
Remove straightforward `mvCapture` calls (some are apparently slightly more tricky to remove).